### PR TITLE
Add mastodon.energy to hypebot servers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,6 +43,8 @@ subscribed_instances:
     limit: 10
   systemli.social:
     limit: 5
+  mastodon.energy:
+    limit: 5
 
 
 filtered_instances:


### PR DESCRIPTION
Thanks for creating and hosting the hypebot, it really helps to find good content on mastodon 👍 

I'm on mastodon.energy and would add it to hypebot, as there are some nice accounts posting on renewable energies and related stuff, for example

- [Jan Rosenow](https://mastodon.energy/@janrosenow)
- [Kees van der Leun](https://mastodon.energy/@Sustainable2050)
- few more

I assume limit=5 is enough as there are not that many accounts on the server.